### PR TITLE
add replicationFactor option

### DIFF
--- a/cfg/cfg.go
+++ b/cfg/cfg.go
@@ -48,6 +48,9 @@ type Route struct {
 	Regex        string
 	Destinations []string
 
+	// consistentHashing
+	ReplicationFactor int
+
 	// grafanaNet & kafkaMdm & Google PubSub
 	SchemasFile  string
 	OrgId        int

--- a/docs/config.md
+++ b/docs/config.md
@@ -75,6 +75,7 @@ type           |     Y     | sendAllMatch/sendFirstMatch/consistentHashing | N/A
 prefix         |     N     | string                                        | ""      |
 sub            |     N     | string                                        | ""      |
 regex          |     N     | string                                        | ""      |
+replicationFactor  |     N     | int                                           | 1       | only for consistentHashing, defines the total number of destinations a matching point will be written to. It must be `0 < replicationFactor < number of destinations`
 
 ### Examples
 
@@ -107,6 +108,20 @@ regex = '(Err/s|wait_time|logger)'
 destinations = [
   'graphite.prod:2003 prefix=prod. spool=true pickle=true',
   'graphite.staging:2003 prefix=staging. spool=true pickle=true'
+]
+
+[[route]]
+# a carbon route that sends to multiple carbon-cache servers
+key = 'carbon-default'
+type = 'consistentHashing'
+prefix = 'consistentHashing'
+# substr = ''
+# regex = ''
+ replicationFactor = 2
+ destinations = [
+  'carbon-cache1:2003 spool=true pickle=false',
+  'carbon-cache2:2003 spool=true pickle=false',
+  'carbon-cache3:2003 spool=true pickle=false'
 ]
 ```
 

--- a/ui/telnet/telnet.go
+++ b/ui/telnet/telnet.go
@@ -85,6 +85,7 @@ commands:
                prefix=<str>                      only take in metrics that have this prefix
                sub=<str>                         only take in metrics that match this substring
                regex=<regex>                     only take in metrics that match this regex (expensive!)
+               replicationFactor=<int>           only for consistentHashing, is the number of destinations for a point, defaults to 1
              <dest>: <addr> <opts>
                <addr>                            a tcp endpoint. i.e. ip:port or hostname:port
                                                  for consistentHashing routes, an instance identifier can also be present:


### PR DESCRIPTION
We want high availability of our data points and backends do not replicate.

Some other relay implementations do that (carbon-c-relay,...) but the replica destinations are not clear.

With this implementation, replicated points are sent to the next servers in the destinations ring.

That means you can deploy your nodes on multiple availability zones and configure the relays accordingly to achieve "rack aware replication".